### PR TITLE
Moment.js's locale will be set automatically now if Moment.js is loaded on the client

### DIFF
--- a/messageformat-client.js
+++ b/messageformat-client.js
@@ -46,6 +46,12 @@ mfPkg.clientInit = function(native, options) {
 		else
 			mfPkg.loadLangs(locale, updateSubs);
 	});
+
+	// if momentjs is used on the client, we reactively change the locale on moment globally
+	if(typeof moment == 'function')
+		Deps.autorun(function() {
+			moment.lang(Session.get('locale') || mfPkg.native);
+		});
 }
 
 /*

--- a/smart.json
+++ b/smart.json
@@ -3,7 +3,7 @@
     "description": "MessageFormat support, i18n the Meteor way",
     "homepage": "https://github.com/gadicohen/meteor-messageformat",
     "author": "Gadi Cohen <dragon@wastelands.net>",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "git": "https://github.com/gadicohen/meteor-messageformat.git",
 	"packages": {
 		"headers": "0.0.12",


### PR DESCRIPTION
The caveat is that currently Moment.js package from Atmosphere does not load the languages (https://github.com/acreeger/meteor-moment/issues/4).
In this case, language change silently fails without any trouble. It is easy to manually add specific language file to the project for now, then mf will change to that language successfully.
