### PR TITLE
various browser compatibility fixes for translation UI

### DIFF
--- a/lib/mfPkg/messageformat-client.js
+++ b/lib/mfPkg/messageformat-client.js
@@ -33,7 +33,7 @@ Handlebars.registerHelper('mf', function(key, message, params) {
 		// temporary, different API
 		if (Meteor.release == "template-engine-preview-10.1")
 			return mf(key, params, message, params ? params.LOCALE : null)
-		else	
+		else
 			return HTML.Raw(mf(key, params, message, params ? params.LOCALE : null));
 	} else {
 		return new Handlebars.SafeString(mf(key, params, message, params ? params.LOCALE : null));
@@ -52,7 +52,7 @@ mfPkg.clientInit = function(native, options) {
 		var locale =
 			mfPkg.sendPolicy == 'all' ? 'all'
 			: Session.get('locale') || mfPkg.native;
-			// console.log(locale); 
+			// console.log(locale);
 
 		// If we requested the lang previously, or requesting native lang,
 		// don't retrieve the strings [again], just update the subscription
@@ -116,7 +116,7 @@ mfPkg.updatedDep = new Deps.Dependency;
 mfPkg.updatedCurrent = false;
 mfPkg.updated = function() {
 	this.updatedDep.depend();
-	return null; 
+	return null;
 }
 Deps.autorun(function() {
 	if (mfPkg.ready() && !mfPkg.updatedCurrent) {
@@ -156,7 +156,7 @@ function updateSubs() {
 	var locale = Session.get('locale') || mfPkg.native;
 	mfPkg.observeFrom(mfPkg.lastSync[locale]);
 	if (mfPkg.mfStringsSub)
-		mfPkg.mfStringsSub.stop();	
+		mfPkg.mfStringsSub.stop();
 	mfPkg.mfStringsSub
 		= Meteor.subscribe('mfStrings', locale,
 			mfPkg.lastSync[locale], false);
@@ -245,7 +245,7 @@ function changeKey(newKey) {
 	var str = mfPkg.mfStrings.findOne({
 		key: newKey, lang: destLang
 	});
-	$('#mfTransDest').val(str ? str.text : '');	
+	$('#mfTransDest').val(str ? str.text : '');
 
 	Session.set('mfTransKey', newKey);
 	$('#mfTransDest').focus();
@@ -285,7 +285,7 @@ Router.map(function() {
 			Session.set('mfTransTrans', this.params.lang);
 
 			// Handle ctrl-up/ctrl-down, respectively
-			$(window).on('keydown.mfTrans', function() {
+			$(window).on('keydown.mfTrans', function(event) {
 				if (event.ctrlKey && (event.which == 38 || event.which == 40)) {
 					event.preventDefault(); event.stopPropagation();
 					var tr = event.which == 38
@@ -294,7 +294,7 @@ Router.map(function() {
 					if (tr.length) {
 						changeKey(tr.data('key'));
 						mfCheckScroll(tr);
-					}					
+					}
 				}
 			});
 
@@ -338,7 +338,7 @@ Template.mfTrans.events({
 });
 
 Template.mfTransLang.events({
-	'click #mfTransLang tr': function() {
+	'click #mfTransLang tr': function(event) {
 		var tr = $(event.target).parents('tr');
 		var key = tr.data('key');
 		if (key) changeKey(key);
@@ -395,7 +395,7 @@ Template.mfTransLang.helpers({
 var initialRender = _.once(function() {
 	var key = Session.get('mfTransKey'),
 		tr = $('#mfTransLang tr[data-key="'+key+'"]');
-	if (tr.length) 
+	if (tr.length)
 		$('#mfTransPreview .tbodyScroll').scrollTop(tr.position().top);
 
 	$('#mfTransDest').focus();
@@ -405,11 +405,12 @@ Template.mfTransLang.rendered = function() {
 	var tr, key = Session.get('mfTransKey');
 
 	// For unset or nonexistent key, set to first row
-	if (!key || !$('tr[data-key=' + key + ']').length) {
+	if (!key || !$('tr[data-key="' + key + '"]').length) {
 		key = $('#mfTransLang tr[data-key]:first-child').data('key');
 		Session.set('mfTransKey', key);
 	}
 
-	$('#mfTransDest').tabOverride();
+	var transDest = $('#mfTransDest');
+	if (typeof transDest.tabOverride === 'function') transDest.tabOverride();
 	initialRender();
 };


### PR DESCRIPTION
We tried the translation UI on firefox and got a bunch of exceptions.
- Some event handlers are using the “event” variable without declaring it as an argument; that's created by magic in some browsers, but relying on that is deprecated.
- We don't have tabOverride(), is that from a jQuery plug-in or a specific version? We're using the jQuery packed with Meteor.
- Selectors like foo[attr="value"] need quotes in the value; most places that were using them had quotes, except for one.

Sorry, but this also includes stripping some trailing whitespace, which my editor does automatically on save.
