### PR TITLE
Fix copy-paste typo

### DIFF
--- a/website/examples/examples.html
+++ b/website/examples/examples.html
@@ -49,10 +49,10 @@
 
 	<a name="simple_helper"></a>
 	<h3>{{mf 'simple_helper' 'String with a variable from a helper function'}}</h3>
-	<!-- {{#mf KEY='hello_name2' NUM=getNum}}
+	<!-- {{#mf KEY='hello_name2' NAME=getName}}
 			Hello, {NAME}.
 		{{/mf}} -->
-	{{#example KEY='hello_name2' NAME=getName paramOverride='NUM=getName'}}
+	{{#example KEY='hello_name2' NAME=getName paramOverride='NAME=getName'}}
 		Hello, {NAME}.
 	{{else}}
 	  Template.main.getName = function() {


### PR DESCRIPTION
In Examples on website, NAME property was written as NUM (probably copy-pasted from previous example).
