### PR TITLE
Allow optional space in `mf` helper

### DIFF
--- a/cli/mf_extract.js
+++ b/cli/mf_extract.js
@@ -123,7 +123,7 @@ function processHtml(file, data) {
 	var result, re;
 
 	// {{mf "key" 'text' attr1=val1 attr2=val2 etc}}
-	re = /{{mf (['"])(.*?)\1 ?(["'])(.*?)\3(.*?)}}/g;
+	re = /{{[\s]?mf (['"])(.*?)\1 ?(["'])(.*?)\3(.*?)}}/g;
 	while (result = re.exec(data)) {
 		var key = result[2], text = result[4], attributes = attrDict(result[5]);
 		var tpl = /<template .*name=(['"])(.*?)\1.*?>[\s\S]*?$/
@@ -140,7 +140,7 @@ function processHtml(file, data) {
 	}
 
 	// {{#mf KEY="key" attr2=val2 etc}}text{{/mf}}
-	re = /{{#mf (.*?)}}\s*([^]*?)\s*{{\/mf}}/g;
+	re = /{{[\s]?#mf (.*?)}}\s*([^]*?)\s*{{\/mf}}/g;
 	while (result = re.exec(data)) {
 		var text = result[2], attributes = attrDict(result[1]), key = attributes.KEY;
 		var tpl = /<template .*name=(['"])(.*?)\1.*?>[\s\S]*?$/


### PR DESCRIPTION
Updated `mf_extract` to be less sensitive with whitespace. Specifically, without this patch, helper blocks with a space before `mf` were not captured. 

Example:

``` html
    <template>
      <h1>{{mf 'header1' 'My Header'}}</h1> <!-- this worked and continues to work -->
      <h1>{{ mf 'header2' 'My InvisibleHeader' }}</h1> <!-- previously not captured by mf_extract -->
    </template>
```
