### PR TITLE
Supporting copy wrighters, more streamlined translation edit.

### DIFF
--- a/msgfmt:extract/extract.js
+++ b/msgfmt:extract/extract.js
@@ -254,7 +254,7 @@ var lastFile = null;
 function logKey(file, key, text, file, line, strings) {
   if (strings[key] && strings[key].text != text)
     log.warn('{ ' + key + ': "' + text + '" } in '
-      + file + ':' + line + ' replaces DUP_KEY\n         { '
+      + file + ':' + line + ' replaces DUP_KEY { '
       + key + ': "' + strings[key].text + '" } in '
       + strings[key].file + ':' + strings[key].line);
 

--- a/msgfmt:extract/extract.js
+++ b/msgfmt:extract/extract.js
@@ -278,16 +278,16 @@ handlers.html = function(file, data, mtime, strings) {
   var result, re;
 
   // {{mf "key" 'text' attr1=val1 attr2=val2 etc}}
-  re = /{{[\s]?mf (['"])(.*?)\1 ?(["'])(.*?)\3(.*?)}}/g;
+  re = /\{\{[\s]?mf ['"](.*?)['"] ?(["'](.*?)['"])?(.*?)\}\}/g;
   while (result = re.exec(data)) {
-    var key = result[2], text = result[4], attributes = attrDict(result[5]);
+    var key = result[1], text = result[3], attributes = attrDict(result[4]);
     var tpl = /<template .*name=(['"])(.*?)\1.*?>[\s\S]*?$/
         .exec(data.substring(0, result.index)); // TODO, optimize
     var line = data.substring(0, result.index).split('\n').length;
     logKey(file, key, text, file, line, strings);
     strings[key] = {
       key: key,
-      text: text,
+      text: text ? text : ("<" + key + ">" ),
       file: file,
       line: line,
       mtime: mtime,

--- a/msgfmt:extract/extract.js
+++ b/msgfmt:extract/extract.js
@@ -266,7 +266,7 @@ function logKey(file, key, text, file, line, strings) {
     log.trace(file);
   }
 
-  log.trace('* ' + key + ': "' + text.replace(/\s+/g, ' ') + '"');
+  log.trace('* ' + key + ': "' + (text ? text.replace(/\s+/g, ' ') : "NO TEXT") + '"');
 }
 
 /* handlers */
@@ -305,7 +305,7 @@ handlers.html = function(file, data, mtime, strings) {
     logKey(file, key, text, file, line, strings);
     strings[key] = {
       key: key,
-      text: text,
+      text: text ? text : ("<" + key + ">" ),
       file: file,
       line: line,
       mtime: mtime,
@@ -328,7 +328,7 @@ handlers.jade = function(file, data, mtime, strings) {
     logKey(file, key, text, file, line, strings);
     strings[key] = {
       key: key,
-      text: text,
+      text: text ? text : ("<" + key + ">" ),
       file: file,
       line: line,
       mtime: mtime,
@@ -346,7 +346,7 @@ handlers.jade = function(file, data, mtime, strings) {
     logKey(file, key, text, file, line, strings);
     strings[key] = {
       key: key,
-      text: text,
+      text: text ? text : ("<" + key + ">" ),
       file: file,
       line: line,
       mtime: mtime,
@@ -374,7 +374,7 @@ handlers.js = function(file, data, mtime, strings) {
     logKey(file, key, text, file, line, strings);
     strings[key] = {
       key: key,
-      text: text,
+      text: text ? text : ("<" + key + ">" ),
       file: file,
       line: line,
       mtime: mtime,
@@ -404,7 +404,7 @@ handlers.coffee = function(file, data, mtime, strings) {
     logKey(file, key, text, file, line, strings);
     strings[key] = {
       key: key,
-      text: text,
+      text: text ? text : ("<" + key + ">" ),
       file: file,
       line: line,
       func: func,

--- a/msgfmt:ui/lib/client.js
+++ b/msgfmt:ui/lib/client.js
@@ -76,20 +76,7 @@ function saveChange(lang, key, text) {
  * Called everytime the current key is changed (ctrl up/down or click)
  */
 function changeKey(newKey) {
-  var destLang = Session.get('mfTransTrans');
-  var oldKey = Session.get('mfTransKey');
-  if (oldKey == newKey) return;
-
-  saveChange(destLang, oldKey, $('#mfTransDest').val());
-
-  // Temporary, need to turn off preserve
-  var str = mfPkg.mfStrings.findOne({
-    key: newKey, lang: destLang
-  });
-  $('#mfTransDest').val(str ? str.text : '');
-
   Session.set('mfTransKey', newKey);
-  $('#mfTransDest').focus();
 }
 
 if (Package['iron:router'])
@@ -132,7 +119,6 @@ Package['iron:router'].Router.map(function() {
               ? $('#mfTransLang tr.current').prev()
               : $('#mfTransLang tr.current').next();
             if (tr.length) {
-              changeKey(tr.data('key'));
               mfCheckScroll(tr);
             }
           }
@@ -203,13 +189,19 @@ Template.mfTransLang.events({
   'click #mfTransLang tr': function(event) {
     var tr = $(event.target).parents('tr'); 
     var key = tr.data('key');
-    if (key) changeKey(key);
+    if (key) changeKey(key, null);
   },
   'click #translationShowKey': function(event) {
     Session.set('translationShowKey', event.currentTarget.checked);
   },
   'click .translationSort': function(event) {
     Session.set('translationSortField', event.currentTarget.attributes['data-sortField'].value);
+  },
+  'change .transInput': function(event) {
+    var destLang = Session.get('mfTransTrans');
+    var key = Session.get('mfTransKey');
+
+    saveChange(destLang, key, $(event.currentTarget).val());
   }
 });
 
@@ -271,8 +263,6 @@ var initialRender = _.once(function() {
     tr = $('#mfTransLang tr[data-key="'+key+'"]');
   if (tr.length)
     $('#mfTransPreview .tbodyScroll').scrollTop(tr.position().top);
-
-  $('#mfTransDest').focus();
 });
 
 Template.mfTransLang.rendered = function() {
@@ -284,7 +274,5 @@ Template.mfTransLang.rendered = function() {
     Session.set('mfTransKey', key);
   }
 
-  var transDest = $('#mfTransDest');
-  if (typeof transDest.tabOverride === 'function') transDest.tabOverride();
   initialRender();
 };

--- a/msgfmt:ui/lib/client.js
+++ b/msgfmt:ui/lib/client.js
@@ -201,13 +201,31 @@ Template.mfTrans.events({
 
 Template.mfTransLang.events({
   'click #mfTransLang tr': function(event) {
-    var tr = $(event.target).parents('tr');
+    var tr = $(event.target).parents('tr'); 
     var key = tr.data('key');
     if (key) changeKey(key);
+  },
+  'click #translationShowKey': function(event) {
+    Session.set('translationShowKey', event.currentTarget.checked);
+  },
+  'click .translationSort': function(event) {
+    Session.set('translationSortField', event.currentTarget.attributes['data-sortField'].value);
   }
 });
 
 Template.mfTransLang.helpers({
+  sortedStrings: function() {
+    var sortField = Session.get('translationSortField');
+    if (!sortField) {
+      Session.set('translationSortField', 'orig');
+    }
+    return this.strings.sort(function(a, b) {
+      return a[sortField] > b[sortField] ? 1 : (a[sortField] < b[sortField] ? -1 : 0);
+    });
+  },
+  showKey: function() {
+    return Session.get('translationShowKey');  
+  },
   stateClass: function() {
     if (this.fuzzy)
       return 'fuzzy';

--- a/msgfmt:ui/lib/ui.css
+++ b/msgfmt:ui/lib/ui.css
@@ -49,6 +49,9 @@ div.mfTransGraph.untrans { background: #800; border-right: 1px solid black; }
 #mfTransPreview table { width: 100%; table-layout:fixed; border-collapse:separate; background: white; }
 #mfTransPreview table thead tr { background: #ede9e3; }
 #mfTransPreview table thead th { width: 50%; padding: 4px 8px 4px 8px; }
+#mfTransPreview table thead th {
+	border-left: 1px solid black; border-top: 1px solid black; border-bottom: 1px solid black;
+}
 #mfTransPreview table thead th:first-child {
 	border-left: 1px solid black; border-top: 1px solid black; border-bottom: 1px solid black;
 	border-top-left-radius: 5px; 

--- a/msgfmt:ui/lib/ui.css
+++ b/msgfmt:ui/lib/ui.css
@@ -42,7 +42,7 @@ div.mfTransGraph.untrans { background: #800; border-right: 1px solid black; }
 }
 
 #mfTransPreview .tbodyScroll {
-	overflow: hidden; height: 200px; overflow-y: scroll;
+	overflow: hidden; height: 400px; overflow-y: scroll;
 	border-left: 1px solid black; border-bottom: 1px solid black;
 	position: relative; /* makes jquery scroll stuff easier */
 }
@@ -80,4 +80,10 @@ div.mfTransGraph.untrans { background: #800; border-right: 1px solid black; }
 	font-family: monospace;
 	height: 5em; width: 100%;
 	margin-top: 5px;
+}
+
+.transInput {
+	width: 100%;
+	border: 1px #ddd dotted;
+	border-style: dashed;
 }

--- a/msgfmt:ui/lib/ui.html
+++ b/msgfmt:ui/lib/ui.html
@@ -66,13 +66,17 @@
 </template>
 
 <template name="mfTransLang">
+{{ debug }}
   <div class="container" id="mfTransLang">
 
     <div id="mfTransPreview">
       <table>
         <thead>
           <tr>
-            <th>Original String ({{orig}})</th>
+            {{#if showKey}}
+              <th><a href="#" class="translationSort" data-sortField="key">Key</a></th>
+            {{/if}}
+            <th><a href="#" class="translationSort" data-sortField="orig">Original String ({{orig}})</a></th>
             <th>Translation ({{trans}})</th>
           </tr>
         </thead>
@@ -80,8 +84,11 @@
       <div class="tbodyScroll">
         <table>
           <tbody>
-          {{#each strings}}
+          {{#each sortedStrings}}
             <tr data-key="{{key}}" class="{{stateClass}} {{isCurrent}}">
+              {{#if showKey}}
+                <td>{{key}}</td>
+              {{/if}}
               <td>{{orig}}</td>
               <td>{{trans}}</td>
             </tr>
@@ -90,7 +97,7 @@
         </table>
       </div>
     </div>
-    <p>Use ctrl-up and ctrl-down to quickly change keys</p>
+    <p><input type="checkbox" id="translationShowKey">Show key, Use ctrl-up and ctrl-down to quickly change keys</p>
     <span><b>{{keyInfo.key}}</b> in {{keyInfo.file}}:{{keyInfo.line
       }}{{#if keyInfo.template}} (template
         {{#if keyInfo.routeUrl}}

--- a/msgfmt:ui/lib/ui.html
+++ b/msgfmt:ui/lib/ui.html
@@ -1,7 +1,8 @@
 <template name="mfTrans">
+{{ debug }}
   <div class="container" id="mfTransContainer">
   <h2>{{mf 'mf_site_translations' 'Site Translations'}}</h2>
-  <p>Native language: <b>{{native}}</b> ({{stats.total}} strings)</p>
+  <p>Native language: <a href="/translate/{{native}}"><b>{{native}}</b></a> ({{stats.total}} strings)</p>
 
   {{#if stats.total}}
 
@@ -90,7 +91,13 @@
                 <td>{{key}}</td>
               {{/if}}
               <td>{{orig}}</td>
-              <td>{{trans}}</td>
+              <td>
+                {{#if isCurrent}}
+                  <input value="{{trans}}" placeholder="{{orig}}" type="text" class="transInput">
+                {{else}}
+                  {{trans}}
+                {{/if}}
+              </td>
             </tr>
           {{/each}}
           </tbody>
@@ -104,11 +111,7 @@
           <a href="{{keyInfo.routeUrl}}">{{keyInfo.template}}</a
         >{{else}}"{{keyInfo.template}}"{{/if}}){{/if
       }}{{#if keyInfo.func}}; {{keyInfo.func}}{{/if}}
-    </span><br />
-    <textarea id="mfTransOrig" readonly>{{mfTransOrig}}</textarea>
-    <textarea id="mfTransDest">{{mfTransTrans}}</textarea>
-
-  <br /><br />
+    </span>
   <p>
     <a href="/translate">Back to Translation Summary</a>
   </p>


### PR DESCRIPTION
1. Ability to show the key in the UI and sort by the key or translation
2. Ability to specify HTML translation as {{ mf ‘key’ }} which automatically names the text as “<$key”>
    - in many scenarios programmer does not care about immediate translations. It is also not clear whether that text has been translated or corrected by copyrighter, so it is better to keep showing only placeholders. placing {{ mf ‘key’ ‘key’ }} seems redundant.
3. Translations are now edited inline not in message boxes below.