### PR TITLE
Use async update to improve app boot-time

### DIFF
--- a/msgfmt:core/lib/mfPkg/messageformat-server.js
+++ b/msgfmt:core/lib/mfPkg/messageformat-server.js
@@ -38,7 +38,7 @@ mfPkg.langUpdate = function(lang, strings, meta, lastSync) {
 	 * the database and update them accordingly, then update mfPkg.string key
 	 */
 
-	var str, existing, revisionId, obj, updating, dbInsert, result, query,
+	var str, existing, revisionId, obj, updating, dbInsert, result, query, asyncErr,
 		optional = ['_id', 'file', 'line', 'template', 'func', 'removed', 'fuzzy'];
 	for (key in strings) {
 		str = strings[key];
@@ -109,8 +109,9 @@ mfPkg.langUpdate = function(lang, strings, meta, lastSync) {
 		if (dbInsert) {
 			obj._id = this.mfStrings.insert(obj)
 		} else {
-			this.mfStrings.update(obj._id, obj);
+			this.mfStrings.update(obj._id, obj, function(err, upc) { if (err) asyncErr = err; });
 		}
+		if (asyncErr) throw asyncErr;
 
 		if (updating) {
 			// does this update affect translations?


### PR DESCRIPTION
I request this small opimization to speed up app boot. Our staging server has abysmal IO-performance and our app start-time is measured in minutes there. We found that messageformat langUpdate() takes a long time to finish. Doing the updates asynchronously lets it finish much faster.

I wasn't too sure how to do the error handling because the errors are delayed. The proposed patch just fails later when one of the updates failed. A lot of operations could happen in between. (I've seen more than twenty async updates fail simultaneously when I killed mongod in the middle of langUpdate().) Because the messageformat updates at startup are nondestructive I assume the behaviour is acceptable, but maybe I don't see the whole picture.
