### PR TITLE
[v2] extract: Allow whitespace before closing parenthesis in .js

### DIFF
--- a/msgfmt:extract/extract.js
+++ b/msgfmt:extract/extract.js
@@ -364,7 +364,7 @@ handlers.js = function(file, data, mtime, strings) {
   // function blah(), blah = function(), helper('moo', function() {...
   // mf('test_key', params, 'test_text'), mf('test_key', 'test_text')
 
-  re = /mf\s*\(\s*(['"])(.*?)\1\s*,\s*.*?\s*,?\s*(['"])(.*?)\3,?.*?\)/g;
+  re = /mf\s*\(\s*(['"])(.*?)\1\s*,\s*.*?\s*,?\s*(['"])(.*?)\3,?.*?\s*\)/g;
   while (result = re.exec(data)) {
     var key = result[2], text = result[4], attributes = attrDict(result[5]);
     if (!text && _.isString(result[3])) text = result[3];


### PR DESCRIPTION
So, I'm a weird dude that sometimes likes to have the closing parenthesis on a newline for function calls.

Currently, 
```js
  var text = mf(
    'textKey',
    {param: 'test'},
    'Lorem ipsum {param}'
  );
```
Would not be a match with the current regex. 

This allows whitespace between the text entry and closing parenthesis for the mf js regex extractions.
