### PR TITLE
[v2] extract: Add Blaze subexpression support in .html regex

### DIFF
--- a/msgfmt:extract/extract.js
+++ b/msgfmt:extract/extract.js
@@ -278,7 +278,8 @@ handlers.html = function(file, data, mtime, strings) {
   var result, re;
 
   // {{mf "key" 'text' attr1=val1 attr2=val2 etc}}
-  re = /{{[\s]?mf (['"])(.*?)\1 ?(["'])(.*?)\3(.*?)}}/g;
+  // or attribute=(mf "key" 'text' attr1=val1 attr2=val2 etc)
+  re = /(?:{{|=\()[\s]?mf (['"])(.*?)\1 ?(["'])(.*?)\3(.*?)(?:}}|\))/g;
   while (result = re.exec(data)) {
     var key = result[2], text = result[4], attributes = attrDict(result[5]);
     var tpl = /<template .*name=(['"])(.*?)\1.*?>[\s\S]*?$/


### PR DESCRIPTION
This allows for subexpressions to be parsed:
```hb
{{> afQuickField name='firstName' 
  autocapitalize="words" label-type='placeholder'
  placeholder=(mf 'firstNamePlaceholder' "First name")
}}
```
It will not work with nested subexpressions, but I don't think they're supported by blaze anyway.

See #154
