### PR TITLE
[v2] core: Log argument key for mf() to ease debugging

### DIFF
--- a/msgfmt:core/lib/mfPkg/messageformat.js
+++ b/msgfmt:core/lib/mfPkg/messageformat.js
@@ -133,8 +133,11 @@ mf = function(key, params, message, locale) {
         if (currentInvocation)
             locale = currentInvocation.connection.locale;
         else {
-            console.log("[msgfmt] You called mf() outside of a method/publish and " +
-                "without specifying a locale, defaulting to native (" + msgfmt.native + ")");
+            console.log(
+              "[msgfmt] You called mf() with the key '" + key +
+              "' outside of a method/publish and " +
+              "without specifying a locale, defaulting to native (" + msgfmt.native + ")"
+            );
             locale = msgfmt.native;
         }
 


### PR DESCRIPTION
Just adding the mf entry key in the logging message to help troubleshoot issues.

![-x0ovc5_aswruvnzgigznnt1nysst_ehplpt-jp3cvm](https://cloud.githubusercontent.com/assets/1521080/11847194/350825b4-a3ea-11e5-9ffa-a057368ad0a0.png)
