### PR TITLE
[v2] core: Add charset=UTF-8 specifier to the Content-Type header

### DIFF
--- a/msgfmt:core/lib/mfPkg/messageformat-server.js
+++ b/msgfmt:core/lib/mfPkg/messageformat-server.js
@@ -334,7 +334,7 @@ WebApp.connectHandlers.use(function(req, res, next) {
 
 function localeStringsToDictionary(res, locale, mtime, flags) {
   var key, out = {};
-  res.setHeader("Content-Type", "application/javascript");
+  res.setHeader("Content-Type", "application/javascript; charset=UTF-8");
   res.writeHead(200);
 
   if (locale === 'all') {


### PR DESCRIPTION
This is just being explicit with the charset for the strings dictionary.

This may not be needed, but bad browsers usually like extra info.