### PR TITLE
[v2] Cordova support workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ msgfmt.init('en', {
 });
 ```
 
+## Cordova
+
+There's an issue with the inject-initial package under Cordova which causes information to not be properly hooked to the client. To counter this, you may define the locales of the application in the settings file, under the public element.
+```json
+{
+  "public": {
+    ...,
+    "localization": {
+      "native": "en",
+      "locales": ["en", "fr"]
+    }
+  }
+}
+```
+
 ### Debug logging
 
 `Logger.setLevel('msgfmt', 'trace');`

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ There's an issue with the inject-initial package under Cordova which causes info
 {
   "public": {
     ...,
-    "localization": {
+    "msgfmt": {
       "native": "en",
       "locales": ["en", "fr"]
     }

--- a/msgfmt:core/lib/mfPkg/messageformat-client.js
+++ b/msgfmt:core/lib/mfPkg/messageformat-client.js
@@ -403,10 +403,10 @@ if (injected) {
   log.debug('Injected object was undefined, this is most likely a Cordova session');
   mfPkg.timestamps = {};
   var time = (new Date()).getTime();
-  if (Meteor.settings && Meteor.settings.public && Meteor.settings.public.localization) {
-    var localization = Meteor.settings.public.localization;
-    mfPkg.native = localization.native;
-    _.each(localization.locales, function(locale) {
+  if (Meteor.settings && Meteor.settings.public && Meteor.settings.public.msgfmt) {
+    var msgfmtSettings = Meteor.settings.public.msgfmt;
+    mfPkg.native = msgfmtSettings.native;
+    _.each(msgfmtSettings.locales, function(locale) {
       mfPkg.timestamps[locale] = time;
     });
   } else {

--- a/msgfmt:core/lib/mfPkg/messageformat-client.js
+++ b/msgfmt:core/lib/mfPkg/messageformat-client.js
@@ -181,7 +181,7 @@ function fetchLocale(locale) {
     locale = 'all';
 
   unique = locale + '/' + (mfPkg.lastSync[locale] || 0);
-  url = '/msgfmt/locale/' + unique;
+  url = Meteor.absoluteUrl('msgfmt/locale/' + unique);
   log.debug('fetchLocale request for "' + locale + '", url: ' + url);
   times.fetches[unique] = Date.now();
 

--- a/msgfmt:core/lib/mfPkg/messageformat-client.js
+++ b/msgfmt:core/lib/mfPkg/messageformat-client.js
@@ -395,9 +395,13 @@ mfPkg.resetStorage = function() {
 /* code below involves loading the actual module at long time */
 
 var injected = Injected.obj('msgfmt');
-mfPkg.timestamps = injected && injected.locales;
-mfPkg.native = injected.native;
-mfPkg.sendPolicy = injected.sendPolicy;
+mfPkg.timestamps = injected ?
+  injected.locales : {
+    'fr': new Date(), 'en': new Date()
+  };
+
+mfPkg.native = injected ? injected.native : 'fr' ;
+mfPkg.sendPolicy = injected ? injected.sendPolicy : 'all';
 
 if (mfPkg.timestamps) {
   (function() {
@@ -433,13 +437,14 @@ if (msgfmt.setBodyDir) {
 var locale = mfPkg.useLocalStorage && amplify.store('mfLocale');
 if (locale) {
   log.debug('Found stored locale "' + locale + '"');
-  mfPkg.setLocale(locale, true /* dontStore */);  
+  mfPkg.setLocale(locale, true /* dontStore */);
 } else if (locale = Session.get('locale')) {
   log.debug('Found session locale "' + locale + '"');
   mfPkg.setLocale(locale);
-} else if (locale = injected.headerLocale) {
+} else if (injected && injected.headerLocale) {
+  locale = injected.headerLocale
   log.debug('Setting locale from header: ' + locale);
-  mfPkg.setLocale(locale);  
+  mfPkg.setLocale(locale);
 } else {
   mfPkg.setLocale(msgfmt.native);
 }

--- a/msgfmt:core/package.js
+++ b/msgfmt:core/package.js
@@ -22,7 +22,7 @@ Package.onUse(function (api) {
     'underscore',
     'ddp',
     'mongo@1.0.4',
-    'meteorhacks:inject-initial@1.0.2',
+    'meteorhacks:inject-initial@1.0.3',
     'jag:pince@0.0.6',
     'raix:eventemitter@0.1.2'
   ], both);


### PR DESCRIPTION
This PR is a workaround to issues I've been having while running under Cordova. It seems there's a problem in inject-initial so that the Injected.get() call returns undefined. Currently it was causing a bunch of errors while loading the package if undefined. [This issue](https://github.com/Nemo64/meteor-translator/issues/9#issuecomment-118207612) was discussing using the settings file to fix the problem, so I used that for now.

I'll admit it feels a bit hacky, but it does work for now.

Also, the Meteor.absoluteUrl('msgfmt/locale/' + unique) change is required so it does not transform the relative url to try to load an embedded resource (which would return a 404 html document instead of a js script, causing a improper syntax error from the tags).

Also updated the inject-initial package to the latest version.

Might fix #131
