### PR TITLE
[v2] extract filters out node_modules folder

### DIFF
--- a/msgfmt:extract/extract.js
+++ b/msgfmt:extract/extract.js
@@ -93,6 +93,7 @@ var checkForUpdates = function(m, force) {
       var file = changedFiles[name];
       var content = fs.readFileSync(file.fromCwd, 'utf8');
       var mtime = new Date(file.mtime).getTime();
+      log.debug('Extracting from ' + name);
       handlers[path.extname(name).substr(1)](name, content, mtime, newStrings);
     }
 

--- a/msgfmt:extract/extract.js
+++ b/msgfmt:extract/extract.js
@@ -42,7 +42,7 @@ var checkForUpdates = function(m, force) {
   var walker  = walk.walk(relUp, {
     followLinks: false,
     filters: [
-      /\/\.[^\.]+\//  // skip .directories (hidden)
+      /\/\.[^\.]+\/|node_modules/  // skip .directories (hidden) & node_modules
     ]
   });
 


### PR DESCRIPTION
Since npm is now used in meteor 1.3, extract needs to ignore that folder.

See #214
