### PR TITLE
sort strings by key by default

### DIFF
--- a/packages/ui/lib/client.js
+++ b/packages/ui/lib/client.js
@@ -377,9 +377,10 @@ Template.mfTransLang.helpers({
   }
 });
 
-Session.setDefault('translationSortField', 'orig');
+Session.setDefault('translationSortField', 'key');
 Session.setDefault('translationSortOrder', 'asc');
-Session.setDefault('translationStatusSort', true);
+Session.setDefault('translationStatusSort', false);
+Session.setDefault('translationShowKey', true);
 Session.setDefault('translationCaseInsensitiveOrdering', false);
 
 var statusValue = function(str) {


### PR DESCRIPTION
fixes #229
maybe helping/fixing #236 

Sort first by status is not that handy when reactive, because translated rows move away as soon as switched to the next string. This behavior is not perceived as intuitive because translators doesn't see what they've just done and the just clicked row moves one up or down on click. 
I sorted it by key so that related strings are grouped.
