### PR TITLE
Fail softer when format text is broken

### DIFF
--- a/packages/core/lib/msgfmt.js
+++ b/packages/core/lib/msgfmt.js
@@ -158,7 +158,7 @@ msgfmt.addCurrencyShortcut = function(currency) {
 msgfmt.addFormat('number', { ZAR: { style: 'currency', currency: 'ZAR' } });
 msgfmt.addCurrencyShortcut('ILS');
 
-mf = function(key, params, message, locale) {
+mf = function mfcall(key, params, message, locale) {
     if (!locale) {
       if (Meteor.isClient) {
         locale = Session.get('locale');
@@ -213,15 +213,21 @@ mf = function(key, params, message, locale) {
         cmessage = mfPkg.compiled[locale][key] = new IntlMessageFormat(message, locale, formats);
     }
 
+    var formatted = key;
     try {
-        //cmessage = cmessage(params);
-        cmessage = cmessage.format(params);
+        formatted = cmessage.format(params);
     }
     catch(err) {
-        cmessage = err;
+        log.warn("Error formatting "+key+" in locale "+locale+": "+err.message);
+        if (locale !== mfPkg.native) {
+            // Retry in native language
+            formatted = mfcall(key, params, message, mfPkg.native);
+        } else {
+            // Give up
+        }
     }
     
-    return cmessage;
+    return formatted;
 }
 
 // Could make this completely private but useful for plugins to use


### PR DESCRIPTION
Hi there!

We had some trouble tracking down a broken translation string. Because broken format strings are a common occurrence for us, I'd like to improve error handling. This patch causes `mf()` to retry in the native language should the translated string fail. 

Thanks for having a look at this. I'm not sure this is the best way to go about it, but at least our site won't show `[Object object]` messages anymore this way :-)

Cheers Stephan
