### PR TITLE
UI improvements

### DIFF
--- a/packages/ui/lib/client.js
+++ b/packages/ui/lib/client.js
@@ -133,7 +133,36 @@ var origOnPopState, origPushState;
 Template.mfTransLang.onCreated(function() {
   // Note, this is in ADDITION to the regular mfStrings sub
   var lang = RouterLayer.getParam('lang');
-  this.subscribe('mfStrings', [mfPkg.native, lang], 0, true);
+  var native = mfPkg.native;
+
+  this.subscribe('mfStrings', [native, lang], 0, true);
+
+  // Build a collection of language pairs for quick lookup
+  var instance = this;
+  instance.pairs = new Mongo.Collection(null);
+  var updatePair = function(entry) {
+      var string = {};
+      if (entry.lang === native) {
+          string.orig = entry.text;
+          string.file = entry.file;
+      }
+      if (entry.lang === lang) {
+          string.trans = entry.text;
+          string.fuzzy = entry.fuzzy;
+      }
+      instance.pairs.update(entry.key, { $set: string });
+  };
+
+  mfPkg.mfStrings.find({ lang: { $in: [lang, native] }, removed: null }).observe({
+      'added': function(entry) {
+          if (!instance.pairs.findOne(entry.key)) {
+              instance.pairs.insert({ _id: entry.key, key: entry.key });
+          }
+          updatePair(entry);
+      },
+      'changed': updatePair
+  });
+
   this.subscribe('mfRevisions', lang, 10);
 
   // Temporary, only used to override preserve on dest
@@ -199,60 +228,19 @@ Template.mfTransLang.helpers({
     var orig = mfPkg.native;
     var lang = RouterLayer.getParam('lang');
 
-    var query = {
-      $and: [{$or: [{lang: orig}, {lang: lang}]},
-        {removed: undefined}]
-    };
-
+    var query = { orig: { $exists: true } };
     var filter = Session.get('mfTransLangFilter');
     if (filter) {
-      filter = new RegExp(filter, 'i');
-      /*
-      since we need to recheck later anyways, no point doing twice
-      query.$and.push({
-        $or: [
-          { key: filter },
-          // { text: filter }, // cant do this here, need both langs
-          { file: filter }
-        ]
-      });
-      */
+        var match = new RegExp(filter, "i");
+        query.$or =
+            [ { key: match }
+            , { orig: match }
+            , { file: match }
+            , { trans: match }
+            ];
     }
-
-    var out = {}, strings = mfPkg.mfStrings.find(query).fetch();
-
-    // summarise matching keys (orig + trans) to a single record
-    _.each(strings, function(str) {
-      if (!out[str.key])
-        out[str.key] = { key: str.key };
-
-      if (str.lang == orig) {
-        out[str.key].orig = str.text;
-        out[str.key].file = str.file;
-      } else {
-        out[str.key].trans = str.text;
-      }
-
-      if (str.fuzzy)
-        out[str.key].fuzzy = true;
-    });
-
-    // reject non-matches (can only do after orig/trans merge)
-    if (filter)
-    _.each(out, function(str, i) {
-      if (!(
-          str.key.match(filter) || 
-          str.file.match(filter) ||
-          str.orig.match(filter) ||
-          (str.trans && str.trans.match(filter))
-            ))
-        delete out[i];
-    });
-
-    strings = _.values(out);
-    strings = sortStrings(strings);
-
-    return strings;
+    var strings = Template.instance().pairs.find(query).fetch();
+    return sortStrings(strings);
   }
 });
 

--- a/packages/ui/lib/client.js
+++ b/packages/ui/lib/client.js
@@ -135,7 +135,10 @@ Template.mfTransLang.onCreated(function() {
   var lang = RouterLayer.getParam('lang');
   var native = mfPkg.native;
 
-  this.subscribe('mfStrings', [native, lang], 0, true);
+  Session.set('mfLoading', true);
+  this.subscribe('mfStrings', [native, lang], 0, true, function() {
+    Session.set('mfLoading', false);
+  });
 
   // Build a collection of language pairs for quick lookup
   var instance = this;
@@ -221,6 +224,7 @@ Template.mfTrans.helpers({
 Template.mfTransLang.helpers({
   origLang: mfPkg.native,
   destLang: function() { return RouterLayer.getParam('lang'); },
+  loading: function() { return Session.get('mfLoading'); },
   allowed: function() {
     return !mfPkg.webUI.allowed.call(this) || mfPkg.webUI.denied.call(this);
   },

--- a/packages/ui/lib/client.js
+++ b/packages/ui/lib/client.js
@@ -381,24 +381,23 @@ var statusValue = function(str) {
 
 var sortStrings = function(strings) {
   var sortField = Session.get('translationSortField');
-  var sortOrder = Session.get('translationSortOrder');
+  var sortOrder = Session.get('translationSortOrder') === 'asc' ? 1 : -1;
   var caseInsensitiveOrdering = Session.get('translationCaseInsensitiveOrdering');
+  var translationStatusSort = Session.get('translationStatusSort');
 
   return strings.sort(function(a, b) {
-    if (Session.get('translationStatusSort')) {
+    if (translationStatusSort) {
       var res = statusValue(a) - statusValue(b);
       if (res) return res; // if 0 continue...
     }
 
     var first = a[sortField] || '';  // avoid undefined in str comparison
     var second = b[sortField] || ''; // avoid undefined in str comparison
-    if (caseInsensitiveOrdering) first = first.toLowerCase();
-    if (caseInsensitiveOrdering) second = second.toLowerCase();
-    if (sortOrder === 'asc') {
-      return first > second ? 1 : (first < second ? -1 : 0);
-    } else {
-      return first > second ? -1 : (first < second ? 1 : 0);
+    if (caseInsensitiveOrdering) {
+        first = first.toLowerCase();
+        second = second.toLowerCase();
     }
+    return first.localeCompare(second) * sortOrder;
   });
 };
 

--- a/packages/ui/lib/ui.html
+++ b/packages/ui/lib/ui.html
@@ -105,6 +105,10 @@
               <td>{{orig}}</td>
               <td>{{trans}}</td>
             </tr>
+          {{else}}
+            <tr>
+                <td>{{#if loading}}Loading...{{else}}Nothing.{{/if}}</td>
+            </tr>
           {{/each}}
           </tbody>
         </table>


### PR DESCRIPTION
Here are some improvements to the translation UI:

- Fixes error when using filter and translation had no `orig` text. (I know, shouldn't happen, but did for us.)
- Improves rendering time by caching the translation pairs in a collection
- Uses `localeCompare` to sort entries
- Shows a loading indicator