### PR TITLE
Fix error on startup a new project

### DIFF
--- a/packages/extract/extract.js
+++ b/packages/extract/extract.js
@@ -241,7 +241,7 @@ Meteor.startup(function() {
       var triggerFile = extractsFile.replace(/~$/,'');
       fs.exists(triggerFile, function(exists) {
         if (!exists)
-          fs.writeFile(triggerFile, '# Used by ' + EXTRACTS_FILE + ', do not delete.\n');
+          fs.writeFile(triggerFile, '# Used by ' + EXTRACTS_FILE + ', do not delete.\n', a, function() { });
       });
     } else {
       log.trace('Creating ' + path.dirname(EXTRACTS_FILE) + ' in app root...');


### PR DESCRIPTION
Since node 10, it is mandatory to pass a callback on fs.writefile() otherwise it throws a TypeError [ERR_INVALID_CALLBACK]: Callback must be a function